### PR TITLE
Pptiketti 98 korjattu2

### DIFF
--- a/ryhmasahkoposti-service/src/main/java/fi/vm/sade/ryhmasahkoposti/service/impl/EmailSender.java
+++ b/ryhmasahkoposti-service/src/main/java/fi/vm/sade/ryhmasahkoposti/service/impl/EmailSender.java
@@ -59,6 +59,8 @@ public class EmailSender {
     private String smtpUsername;
     @Value("${ryhmasahkoposti.smtp.password}")
     private String smtpPassword;
+    @Value("${ryhmasahkoposti.smtp.return_path}")
+    private String smtpReturnPath;
 
     public void handleMail(EmailMessage emailMessage, String emailAddress,
                            String letterHash, Optional<? extends AttachmentContainer> additionalAttachments) throws Exception {
@@ -101,7 +103,9 @@ public class EmailSender {
         }
         msg.addHeader("X-Batch-ID", "Opetushallitus");
         msg.addHeader("X-Message-ID", letterHash + ".posti@hard.ware.fi");
-        msg.addHeader("Return-Path", "shredder@shredder.ware.fi");
+        if (smtpReturnPath != null && smtpReturnPath.length() > 0) {
+            msg.addHeader("Return-Path", smtpReturnPath);
+        }
 
         MimeMultipart msgContent = new MimeMultipart("mixed");
         MimeBodyPart bodyPart = new MimeBodyPart();

--- a/src/main/resources/oph-configuration/viestintapalvelu.properties.template
+++ b/src/main/resources/oph-configuration/viestintapalvelu.properties.template
@@ -27,6 +27,7 @@ ryhmasahkoposti.smtp.use_tls={{ryhmasahkoposti_smtp_use_tls}}
 ryhmasahkoposti.smtp.authenticate={{ryhmasahkoposti_smtp_authenticate}}
 ryhmasahkoposti.smtp.username={{ryhmasahkoposti_smtp_username}}
 ryhmasahkoposti.smtp.password={{ryhmasahkoposti_smtp_password}}
+ryhmasahkoposti.smtp.return_path={{ryhmasahkoposti_smtp_return_path}}
 ryhmasahkoposti.antivirus.host={{ryhmasahkoposti_antivirus_host}}
 ryhmasahkoposti.antivirus.port={{ryhmasahkoposti_antivirus_port}}
 ryhmasahkoposti.antivirus.timeout={{ryhmasahkoposti_antivirus_timeout}}
@@ -99,7 +100,7 @@ ryhmasahkoposti.queue.handle.size=250
 ryhmasahkoposti.max.sendqueue.tasks.to.add=42
 ryhmasahkoposti.sender.cron=0 * * * * *
 ryhmasahkoposti.max.email.recipient.handle.time.millis = 180000
-ryhmasahkoposti.from=noreply@opintopolku.fi
+ryhmasahkoposti.from={{ryhmasahkoposti_smtp_sender}}
 # Ryhmäsähköpostin oletuspohja ja oletuspohjan kieli
 ryhmasahkoposti.default.template.name=osoitepalvelu_email
 ryhmasahkoposti.default.template.language=FI


### PR DESCRIPTION
Korjattu loput SES:in SMTP-palvelimen käyttöön liittyvät ongelmat. 

Autentikointi tehty nyt toimivaksi todetulla tavalla Session-objektiin sen sijaan että se yritettäisiin tehdä transport.connectissa, mikä ei käytännössä toiminutkaan. 

Lisäksi lähettäjän osoite sekä Return-Path-headeriin laitettava osoite konfiguroidaan ympäristökohtaisesti, jotta ne saadaan toimivaan muotoon pilviympäristöihin.